### PR TITLE
mod for side panel mode and buffer copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 <img width="1480" alt="image" src="https://github.com/user-attachments/assets/eac126c5-e71c-4de9-817a-bf4e8f2f6af9" />
 
 ## A Neovim plugin integrating the open-sourced Codex CLI (`codex`).
-> Latest version: ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/johnseth97/codex.nvim?sort=semver)
+> Latest version: ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/kkrampis/codex.nvim?sort=semver)
 
 Note: As of v1.0.0, <Esc> no longer closes the Codex window. Press q to close, and <Esc><Esc> to safely interrupt model generation without resetting context.
 
 ### Features:
-- ✅ Toggle Codex floating window with `:CodexToggle`
+- ✅ Toggle Codex window or side-panel with `:CodexToggle`
 - ✅ Optional keymap mapping via `setup` call
 - ✅ Background running when window hidden
 - ✅ Statusline integration via `require('codex').status()` 
@@ -31,14 +31,14 @@ export OPENAI_API_KEY=your_api_key
 
 ```lua
 return {
-  'johnseth97/codex.nvim',
+  'kkrampis/codex.nvim',
   lazy = true,
   cmd = { 'Codex', 'CodexToggle' }, -- Optional: Load only on command execution
   keys = {
     {
       '<leader>cc', -- Change this to your preferred keybinding
       function() require('codex').toggle() end,
-      desc = 'Toggle Codex popup',
+      desc = 'Toggle Codex popup or side-panel',
     },
   },
   opts = {
@@ -48,12 +48,16 @@ return {
     height      = 0.8,        -- Height of the floating window (0.0 to 1.0)
     model       = nil,        -- Optional: pass a string to use a specific model (e.g., 'o3-mini')
     autoinstall = true,       -- Automatically install the Codex CLI if not found
+    panel       = false,      -- Open Codex in a side-panel (vertical split) instead of floating window
+    use_buffer  = false,      -- Capture Codex stdout into a normal buffer instead of a terminal buffer
   },
 }```
 
 ### Usage:
-- Call `:Codex` (or `:CodexToggle`) to open or close the Codex popup.
--- Map your own keybindings via the `keymaps.toggle` setting.
+- Call `:Codex` (or `:CodexToggle`) to open or close the Codex popup or side-panel.
+- Map your own keybindings via the `keymaps.toggle` setting.
+- To choose floating popup vs side-panel, set `panel = false` (popup) or `panel = true` (panel) in your setup options.
+- To capture Codex output in an editable buffer instead of a terminal, set `use_buffer = true` (or `false` to keep terminal) in your setup options.
 - Add the following code to show backgrounded Codex window in lualine:
 
 ```lua
@@ -64,4 +68,3 @@ require('codex').status() -- drop in to your lualine sections
 - All plugin configurations can be seen in the `opts` table of the plugin setup, as shown in the installation section.
 
 - **For deeper customization, please refer to the [Codex CLI documentation](https://github.com/openai/codex?tab=readme-ov-file#full-configuration-example) full configuration example. These features change quickly as Codex CLI is in active beta development.*
-


### PR DESCRIPTION
Added the option to have it as buffer / split panel within neovim (can be enabled with true-false in the plugin configuration file). Also allows for vim normal mode yanking of output from codex and pasting into any other open buffer.

<img width="2160" height="1350" alt="2025-08-14T22:26:54,443827083-04:00" src="https://github.com/user-attachments/assets/995006d7-eb3d-4828-a491-d94a0c0582b2" />